### PR TITLE
fix: implement natural sorting of ts segments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,9 @@ export async function download(config: IConfig): Promise<void> {
 
     // Get all segments
     const segments = fs.readdirSync(segmentsDir).map((f) => segmentsDir + f);
-    segments.sort();
+    segments.sort((a: string, b: string) => {
+        return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+    });
 
     // Merge TS files
     const mergeFunction = config.mergeUsingFfmpeg ? mergeChunksFfmpeg : mergeChunksStream;


### PR DESCRIPTION
There was a bug in the code where segments were sorted but not using a natural sorting algorithm resulting in the video segments concatenating out of order and then the video being out of wack:

Before fix:
```
  '/tmp/hls-downloader/1614334710367/seg-1-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-10-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-11-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-12-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-13-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-14-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-15-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-16-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-17-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-18-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-19-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-2-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-20-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-21-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-22-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-23-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-24-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-25-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-26-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-27-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-28-v1-a1.ts',
  '/tmp/hls-downloader/1614334710367/seg-29-v1-a1.ts',
  ...
```

After fix:
```
 '/tmp/hls-downloader/1614334849031/seg-1-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-2-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-3-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-4-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-5-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-6-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-7-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-8-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-9-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-10-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-11-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-12-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-13-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-14-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-15-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-16-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-17-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-18-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-19-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-20-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-21-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-22-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-23-v1-a1.ts',
  '/tmp/hls-downloader/1614334849031/seg-24-v1-a1.ts',
  ...
```