### PR TITLE
Add Retry & Max Retries

### DIFF
--- a/src/ChunksLiveDownloader.ts
+++ b/src/ChunksLiveDownloader.ts
@@ -49,7 +49,7 @@ export class ChunksLiveDownloader extends ChunksDownloader {
         this.lastSegment = toLoad[toLoad.length - 1];
         for (const uri of toLoad) {
             this.logger.log("Queued:", uri);
-            this.queue.add(() => this.downloadSegment(uri));
+            this.queue.add(() => this.downloadSegment(uri, 1, 1));
         }
 
         // Timeout after X seconds without new segment

--- a/src/ChunksStaticDownloader.ts
+++ b/src/ChunksStaticDownloader.ts
@@ -8,6 +8,7 @@ export class ChunksStaticDownloader extends ChunksDownloader {
         logger: ILogger,
         playlistUrl: string,
         concurrency: number,
+        private maxRetries: number,
         segmentDirectory: string,
         httpHeaders?: HttpHeaders,
     ) {
@@ -20,7 +21,7 @@ export class ChunksStaticDownloader extends ChunksDownloader {
 
         this.logger.log(`Queueing ${segments.length} segment(s)`);
         for (const uri of segments) {
-            this.queue.add(() => this.downloadSegment(uri));
+            this.queue.add(() => this.downloadSegment(uri, this.maxRetries, 1));
         }
 
         this.queue.onIdle().then(() => this.finished());

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -7,6 +7,7 @@ export interface IConfig {
     concurrency?: number;
     live?: boolean;
     fromEnd?: number;
+    maxRetries?: number;
     quality?: "worst" | "best" | number;
     streamUrl: string;
     segmentsDir?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export async function download(config: IConfig): Promise<void> {
             logger,
             playlistUrl,
             config.concurrency || 1,
+            config.maxRetries || 1,
             segmentsDir,
             config.httpHeaders,
         );


### PR DESCRIPTION
With the current implementation Exceptions are simply thrown and the whole download process is stopped if one Chunk fails. 

This happened to me due to an unstable internet connection at my place. I implemented a max retry property to make sure the StaticChunkDownloader can restart certain chunks without running into an endless loop.